### PR TITLE
Add a whitelist for swap bots

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,11 @@ var cooldownTimes = {}; // Cooldown timers by user, id and timestamp
 /* Latest active users */
 var activeUsers = []; 
 
+/* Whitelisted interfacable bots */
+var whitelistedBots = [
+  "918146218511708260" //RoyalSwap
+];
+
 /* BOT ENABLE/DISABLE */
 var botEnabled = 1;
 
@@ -66,8 +71,8 @@ client.on('message', msg => {
   if(userID == config.bot.botID) 
     return;
 
-  // Only check if its not other bot
-  if(userBot) 
+  // Only check if its a normal user, or the bot is in the whitelist
+  if(userBot && whitelistedBots.indexOf(msg.author.id) == -1) 
     return;
 
   // Save and delete active users by time


### PR DESCRIPTION
Added a whitelist for swap bots (and other types of bots) that will need wallets so they can integrate with VGC, and hard coded RoyalSwap into it to start.  I was looking for the faucet command to exclude the bot from that but couldn't find it.  Suggest adding a separate bot check around that command to make sure even white listed bots can't run faucet commands.