### PR TITLE
Update drop phrase limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Convert balance to normal balance (Only once within 24 hours if no stake/unstake
 Tip a user from Discord.  
 ```+rain <all/online/random> <amount> <userCount>```  
 (all) Tip amount divided by total user count. / (online) Tip amount divided by active users. / (random) Tip amount divided by random user count.
-```+drop <phrase/react> <amount> <timeInSeconds> <30 letter phrase>```  
+```+drop <phrase/react> <amount> <timeInSeconds> <40 letter phrase>```
 (phrase) Send coins to all users that reply with the asked phrase. / (react) Send coins to all users that react with the asked icon.  
 ```+history <deposits/withdrawals/payments> | +history <d/w/p>```  
 (deposits) Show your latest deposits. / (withdrawals) Show your latest withdrawals. / (payments) Show your latest payments. 

--- a/config.js
+++ b/config.js
@@ -25,7 +25,8 @@ module.exports = {
         "dropMinSeconds": 10, // Drop message min reply time in seconds
         "dropMaxSeconds": 300, // Drop message max reply time in seconds
         "dropMinUsers": 1, // Users minimum needed for drop
-        "minDropValue": 0.00000001, // Minimum value for drop 
+        "dropMessageMaxLength": 40, // Max length for the drop phrase
+        "minDropValue": 0.00000001, // Minimum value for drop
     }, 
     "mysql":{ // Dont forget to import the empty database before starting the bot
         "dbHost": process.env.DB_HOST || "XXX", // Database server
@@ -56,7 +57,7 @@ module.exports = {
         "withdrawalsHistoryDisplayCount": 5, // How many withdrawals get shown on withdrawal history command !! Max value 5 !!
         "paymentHistoryCoun": 7, // How many payments get shown on withdrawals payments command !! Max value 7 !!
         "explorerLinkAddress": "https://explorer.link/#/address/", // Explorer link address for addresses
-        "explorerLinkTransaction": "ttps://explorer.link/#/tx/", // Explorer link transaction
+        "explorerLinkTransaction": "https://explorer.link/#/tx/", // Explorer link transaction
         "transactionFee": 0.01, // Fee taken for a transaction a user makes - Change value also on help command
         "minWithdrawalValue": 0.00000001, // Minimum value for withdrawal
         "minTipValue": 0.00000001, // Minimum value for tip 


### PR DESCRIPTION
## Summary
- cap drop phrases with `dropMessageMaxLength`
- use secure URL for the explorer link
- document new phrase limit
